### PR TITLE
created utils.py added basic convenience methods

### DIFF
--- a/osometweet/utils.py
+++ b/osometweet/utils.py
@@ -1,0 +1,288 @@
+""" A collection of utility and convenience functions."""
+
+
+def chunker(seq: list, size: int) -> list:
+    """ Turns a list (seq) into a list of
+    smaller lists len <= size, where only the
+    last list will have len < size.
+
+    :param iterable seq
+    :param int size
+
+    return list
+    ~~~
+
+    Example Usage:
+
+	import osometweet.utils as o_utils
+    my_list = [1,2,3,4,5,6,7,8,9]
+    o_utils.chunker(seq = my_list, size = 2)
+    [[1, 2], [3, 4], [5, 6], [7, 8], [9]]
+    """
+    if isinstance(seq, list) == False:
+        raise ValueError("`seq` must be a list")
+    return list(seq[pos:pos + size] for pos in range(0, len(seq), size))
+
+
+class ObjectFields():
+    """ Class of convenience methods for Twitter's object fields.
+    """
+
+    # Show Fields
+    # ~~~~~~~~~~~~~~~
+    def show_user_fields():
+        """ Show all possible twitter v2 user fields.
+        ~~~
+
+        Example Usage:
+
+        from osometweet.utils import ObjectFields as fields
+        fields.show_user_fields()
+        """
+        fields = [
+            "Twitter V2 Available User Fields:",
+            "created_at",
+            "description",
+            "entities",
+            "id",
+            "location",
+            "name",
+            "pinned_tweet_id",
+            "profile_image_url",
+            "protected",
+            "public_metrics",
+            "url",
+            "username",
+            "verified",
+            "withheld",
+            "Reference: https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/user"
+        ]
+        print(*fields, sep="\n-")
+
+    def show_tweet_fields():
+        """ Show all possible twitter v2 user fields.
+        ~~~
+
+        Example Usage:
+
+        from osometweet.utils import ObjectFields as fields
+        fields.show_tweet_fields()
+        """
+        fields = [
+            "Twitter V2 Available Tweet Fields:",
+            "attachments",
+            "author_id",
+            "context_annotations",
+            "conversation_id",
+            "created_at",
+            "entities",
+            "geo",
+            "id",
+            "in_reply_to_user_id",
+            "lang",
+            "non_public_metrics",
+            "organic_metrics",
+            "possiby_sensitive",
+            "promoted_metrics",
+            "public_metrics",
+            "referenced_tweets",
+            "reply_settings",
+            "source",
+            "text",
+            "withheld",
+            "Reference: https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/tweet"
+        ]
+        print(*fields, sep="\n-")
+
+    def show_media_fields():
+        """ Show all possible twitter v2 user fields.
+        ~~~
+
+        Example Usage:
+
+        from osometweet.utils import ObjectFields as fields
+        fields.show_media_fields()
+        """
+        fields = [
+            "Twitter V2 Available Media Fields:",
+            "duration_ms",
+            "height",
+            "media_key",
+            "non_public_metrics",
+            "organic_metrics",
+            "preview_image_url",
+            "promoted_metrics",
+            "public_metrics",
+            "type",
+            "width",
+            "Reference: https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/media"
+        ]
+        print(*fields, sep="\n-")
+
+    def show_poll_fields():
+        """ Show all possible twitter v2 poll fields.
+        ~~~
+
+        Example Usage:
+
+        from osometweet.utils import ObjectFields as fields
+        fields.show_poll_fields()
+        """
+        fields = [
+            "Twitter V2 Available Poll Fields:",
+            "duration_minutes",
+            "end_datetime",
+            "id",
+            "options",
+            "voting_status",
+            "Reference: https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/poll"
+        ]
+        print(*fields, sep="\n-")
+
+    def show_place_fields():
+        """ Show all possible twitter v2 poll fields.
+        ~~~
+
+        Example Usage:
+
+        from osometweet.utils import ObjectFields as fields
+        fields.show_place_fields()
+        """
+        fields = [
+            "Twitter V2 Available Place Fields:",
+            "contained_within",
+            "country",
+            "country_code",
+            "full_name",
+            "geo",
+            "id",
+            "name",
+            "place_type",
+            "Reference: https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/place"
+        ]
+        print(*fields, sep="\n-")
+
+    # Return Fields
+    # ~~~~~~~~~~~~~~~
+    def return_user_fields():
+        """ Return all possible twitter v2 user fields as a list.
+        ~~~
+
+        Example Usage:
+
+        from osometweet.utils import ObjectFields as fields
+        fields.return_user_fields()
+
+        """
+        fields = [
+            "created_at",
+            "description",
+            "entities",
+            "id",
+            "location",
+            "name",
+            "pinned_tweet_id",
+            "profile_image_url",
+            "protected",
+            "public_metrics",
+            "url",
+            "username",
+            "verified",
+            "withheld"
+        ]
+        return fields
+
+    def return_tweet_fields():
+        """ Return all possible twitter v2 tweet fields as a list.
+        ~~~
+
+        Example Usage:
+
+        from osometweet.utils import ObjectFields as fields
+        fields.return_tweet_fields()
+        """
+        fields = [
+            "attachments",
+            "author_id",
+            "context_annotations",
+            "conversation_id",
+            "created_at",
+            "entities",
+            "geo",
+            "id",
+            "in_reply_to_user_id",
+            "lang",
+            "non_public_metrics",
+            "organic_metrics",
+            "possiby_sensitive",
+            "promoted_metrics",
+            "public_metrics",
+            "referenced_tweets",
+            "reply_settings",
+            "source",
+            "text",
+            "withheld"
+        ]
+        return fields
+
+    def return_media_fields():
+        """ Return all possible twitter v2 media fields as a list.
+        ~~~
+
+        Example Usage:
+
+        from osometweet.utils import ObjectFields as fields
+        fields.return_media_fields()
+        """
+        fields = [
+            "duration_ms",
+            "height",
+            "media_key",
+            "non_public_metrics",
+            "organic_metrics",
+            "preview_image_url",
+            "promoted_metrics",
+            "public_metrics",
+            "type",
+            "width"
+        ]
+        return fields
+
+    def return_poll_fields():
+        """ Return all possible twitter v2 poll fields as a list.
+        ~~~
+
+        Example Usage:
+
+        from osometweet.utils import ObjectFields as fields
+        fields.return_poll_fields()
+        """
+        fields = [
+            "duration_minutes",
+            "end_datetime",
+            "id",
+            "options",
+            "voting_status"
+        ]
+        return fields
+
+    def return_place_fields():
+        """ Return all possible twitter v2 place fields as a list.
+        ~~~
+
+        Example Usage:
+
+        from osometweet.utils import ObjectFields as fields
+        fields.return_place_fields()
+        """
+        fields = [
+            "contained_within",
+            "country",
+            "country_code",
+            "full_name",
+            "geo",
+            "id",
+            "name",
+            "place_type",
+        ]
+        return fields


### PR DESCRIPTION
I created a new file, `utils.py`, which contains a single convenience function `chunker` and a new class `ObjectFields` which contains a number of other convenience functions, all of which consist of two types.
* `chunker`: Turns a list into a list of smaller lists where the length of those smaller lists are no longer than the user indicated size.
```python
from osometweet import utils as o_util
my_list = ["user1","user2","user3","user4","user5","user6","user7","user8","user9"]
chunked_list = o_util.chunker(seq = my_list, size = 2)
print(chunked_list)
~~~
[['user1', 'user2'], ['user3', 'user4'], ['user5', 'user6'], ['user7', 'user8'], ['user9']]
```
This is useful for any other method which can only query a certain number of items at one time (i.e. user/tweets).

* ObjectFields:
    * `return_object_fields` : methods to return a list of the available Twitter object fields
    * `show_object_fields` : methods to print a list of the available Twitter object fields as well as a link to a reference page on [developer.twitter.com]().
    * Methods exists for each object field (i.e. `return_tweet_fields()`,  `return_user_fields()`, `show_tweet_fields()`,  `show_user_fields()`  etc.)

```python
from osometweet.utils import ObjectFields as fields
fields.show_place_fields()
~~~
Twitter V2 Available Place Fields:
-contained_within
-country
-country_code
-full_name
-geo
-id
-name
-place_type
-Reference: https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/place
```
Considering a large part of the v2 API is built around playing with these different fields, I think this will be very useful.

Eventually, I'd like to add a parameter for expansions - e.g. calling `fields.show_place_fields(expansions = True)` will also show you which expansions you can include with that data object, but this is for another day. 